### PR TITLE
Use environment variables for secrets (passwords and API keys)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Django settings
+DJANGO_SECRET_KEY=your-secret-key-here
+DJANGO_SETTINGS_MODULE=role_play.settings.local
+
+# PostgreSQL database password
+POSTGRES_PASSWORD=your-secure-password-here
+
+# Anthropic API key
+ANTHROPIC_API_KEY=your-anthropic-api-key-here

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,9 +9,9 @@ services:
     image: "postgres:alpine"
     restart: always
     environment:
-      - POSTGRES_USER=devuser
-      - POSTGRES_PASSWORD=devpwd
-      - POSTGRES_DB=role-play
+      POSTGRES_USER: devuser
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: role-play
     ports:
       - "5432:5432"
     volumes:


### PR DESCRIPTION
- Replace hardcoded PostgreSQL password with POSTGRES_PASSWORD env var in docker-compose.yml
- Update local.py and ci.py settings to use POSTGRES_PASSWORD from environment
- Add .env.example file to document required secret environment variables
- Keep non-sensitive config (usernames, db names, hosts, ports) hardcoded
- All 299 tests passing with Doppler environment variable injection