### PR TITLE
fix: update PostgreSQL volume path for version 18

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     ports:
       - "5432:5432"
     volumes:
-      - db-data:/var/lib/postgresql/data
+      - db-data:/var/lib/postgresql
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U devuser -d role-play"]
       interval: 10s


### PR DESCRIPTION
PostgreSQL 18 changed PGDATA from /var/lib/postgresql/data to /var/lib/postgresql/18/docker. Mount at /var/lib/postgresql to avoid anonymous volume creation.