### PR TITLE
chore: pin Redis and PostgreSQL versions in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     services:
       redis:
-        image: redis:latest
+        image: redis:8
         ports:
           - 6379:6379
         options: >-
@@ -20,7 +20,7 @@ jobs:
           --health-timeout 5s
           --health-retries 5
       postgres:
-        image: postgres:latest
+        image: postgres:18
         env:
           POSTGRES_USER: ciuser
           POSTGRES_PASSWORD: ${{secrets.POSTGRES_PASSWORD}}


### PR DESCRIPTION
- Redis: latest → 8
- PostgreSQL: latest → 18

Matches docker-compose.yml versions for consistency.