### PR TITLE
feat: add empty default option to character creation dropdowns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
 * Split CI workflow into separate lint and test jobs for faster feedback
 * Deploy workflow now runs tests before deploying to production
 * Added manual deployment trigger via workflow_dispatch
+* Character creation dropdowns now show empty "---------" placeholder by default instead of pre-selecting the first option
 
 ## v0.12.0 - 2025-01-18
 

--- a/character/forms/backgrounds.py
+++ b/character/forms/backgrounds.py
@@ -53,37 +53,39 @@ def _get_artisans_tools() -> set[tuple[str, str]]:
 
 
 class BackgroundForm(forms.Form):
+    EMPTY_CHOICE = ("", "---------")
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         race = self.initial["race"]
         background = self.initial["background"]
         all_fields = {}
         all_fields["language"] = forms.ChoiceField(
-            choices=_get_non_spoken_languages(race),
+            choices=[self.EMPTY_CHOICE, *_get_non_spoken_languages(race)],
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["first_language"] = forms.ChoiceField(
-            choices=_get_non_spoken_languages(race),
+            choices=[self.EMPTY_CHOICE, *_get_non_spoken_languages(race)],
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["second_language"] = forms.ChoiceField(
-            choices=_get_non_spoken_languages(race),
+            choices=[self.EMPTY_CHOICE, *_get_non_spoken_languages(race)],
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["equipment_holy_symbols"] = forms.ChoiceField(
-            choices=_get_holy_symbols(),
+            choices=[self.EMPTY_CHOICE, *_get_holy_symbols()],
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["equipment_artisans_tools"] = forms.ChoiceField(
-            choices=_get_artisans_tools(),
+            choices=[self.EMPTY_CHOICE, *_get_artisans_tools()],
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["tool_proficiency_artisans_tools"] = forms.ChoiceField(
-            choices=_get_artisans_tools(),
+            choices=[self.EMPTY_CHOICE, *_get_artisans_tools()],
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["tool_proficiency_gaming_set_tools"] = forms.ChoiceField(
-            choices=_get_gaming_set_tools(),
+            choices=[self.EMPTY_CHOICE, *_get_gaming_set_tools()],
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         match background:

--- a/character/forms/character.py
+++ b/character/forms/character.py
@@ -6,6 +6,8 @@ from .mixins import NoDuplicateValuesFormMixin
 
 
 class CharacterCreateForm(NoDuplicateValuesFormMixin, forms.ModelForm):
+    EMPTY_CHOICE = ("", "---------")
+
     class Meta:
         model = Character
         fields = [
@@ -21,32 +23,32 @@ class CharacterCreateForm(NoDuplicateValuesFormMixin, forms.ModelForm):
         }
 
     strength = forms.TypedChoiceField(
-        choices=AbilityScore.choices,
+        choices=[EMPTY_CHOICE, *AbilityScore.choices],
         coerce=int,
         widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
     )
     dexterity = forms.TypedChoiceField(
-        choices=AbilityScore.choices,
+        choices=[EMPTY_CHOICE, *AbilityScore.choices],
         coerce=int,
         widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
     )
     constitution = forms.TypedChoiceField(
-        choices=AbilityScore.choices,
+        choices=[EMPTY_CHOICE, *AbilityScore.choices],
         coerce=int,
         widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
     )
     intelligence = forms.TypedChoiceField(
-        choices=AbilityScore.choices,
+        choices=[EMPTY_CHOICE, *AbilityScore.choices],
         coerce=int,
         widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
     )
     wisdom = forms.TypedChoiceField(
-        choices=AbilityScore.choices,
+        choices=[EMPTY_CHOICE, *AbilityScore.choices],
         coerce=int,
         widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
     )
     charisma = forms.TypedChoiceField(
-        choices=AbilityScore.choices,
+        choices=[EMPTY_CHOICE, *AbilityScore.choices],
         coerce=int,
         widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
     )

--- a/character/forms/equipment.py
+++ b/character/forms/equipment.py
@@ -10,6 +10,12 @@ from .equipment_choices_providers import (
 
 
 class EquipmentSelectForm(forms.Form):
+    EMPTY_CHOICE = ("", "---------")
+
+    def _get_choices(self, choices):
+        """Return choices with empty choice prepended, or just empty choice if None."""
+        return [self.EMPTY_CHOICE, *choices] if choices else [self.EMPTY_CHOICE]
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         klass = self.initial["klass"]
@@ -28,27 +34,27 @@ class EquipmentSelectForm(forms.Form):
                 fields = ["first_weapon", "gear", "pack"]
         all_fields = {}
         all_fields["first_weapon"] = forms.ChoiceField(
-            choices=choices_provider.get_first_weapon_choices(),
+            choices=self._get_choices(choices_provider.get_first_weapon_choices()),
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["second_weapon"] = forms.ChoiceField(
-            choices=choices_provider.get_second_weapon_choices(),
+            choices=self._get_choices(choices_provider.get_second_weapon_choices()),
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["third_weapon"] = forms.ChoiceField(
-            choices=choices_provider.get_third_weapon_choices(),
+            choices=self._get_choices(choices_provider.get_third_weapon_choices()),
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["armor"] = forms.ChoiceField(
-            choices=choices_provider.get_armor_choices(),
+            choices=self._get_choices(choices_provider.get_armor_choices()),
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["gear"] = forms.ChoiceField(
-            choices=choices_provider.get_gear_choices(),
+            choices=self._get_choices(choices_provider.get_gear_choices()),
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         all_fields["pack"] = forms.ChoiceField(
-            choices=choices_provider.get_pack_choices(),
+            choices=self._get_choices(choices_provider.get_pack_choices()),
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         for field in fields:

--- a/character/forms/skills.py
+++ b/character/forms/skills.py
@@ -56,23 +56,26 @@ def _get_skills(klass: Klass) -> set[tuple[str, str]] | None:
 
 
 class SkillsSelectForm(NoDuplicateValuesFormMixin, forms.Form):
+    EMPTY_CHOICE = ("", "---------")
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         klass = self.initial["klass"]
+        choices = [self.EMPTY_CHOICE, *_get_skills(klass)]
         self.fields["first_skill"] = forms.ChoiceField(
-            choices=_get_skills(klass),
+            choices=choices,
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         self.fields["second_skill"] = forms.ChoiceField(
-            choices=_get_skills(klass),
+            choices=choices,
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         if klass == Klass.ROGUE:
             self.fields["third_skill"] = forms.ChoiceField(
-                choices=_get_skills(klass),
+                choices=choices,
                 widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
             )
             self.fields["fourth_skill"] = forms.ChoiceField(
-                choices=_get_skills(klass),
+                choices=choices,
                 widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
             )


### PR DESCRIPTION
- Add '---------' placeholder to skills form (step 2)
- Add '---------' placeholder to backgrounds form (step 3)
- Add '---------' placeholder to equipment form (step 4)
- Add '---------' placeholder to ability score dropdowns (step 1)

This ensures users must explicitly select a value instead of having the first option pre-selected by default.