### PR TITLE
feat: hide dropdown fields when no choices are available

### DIFF
--- a/character/constants/abilities.py
+++ b/character/constants/abilities.py
@@ -2,12 +2,12 @@ from django.db.models import IntegerChoices, TextChoices
 
 
 class AbilityName(TextChoices):
-    STRENGTH = "STR", "strength"
-    DEXTERITY = "DEX", "dexterity"
-    CONSTITUTION = "CON", "constitution"
-    INTELLIGENCE = "INT", "intelligence"
-    WISDOM = "WIS", "wisdom"
-    CHARISMA = "CHA", "charisma"
+    STRENGTH = "STR", "Strength"
+    DEXTERITY = "DEX", "Dexterity"
+    CONSTITUTION = "CON", "Constitution"
+    INTELLIGENCE = "INT", "Intelligence"
+    WISDOM = "WIS", "Wisdom"
+    CHARISMA = "CHA", "Charisma"
 
 
 class AbilityScore(IntegerChoices):

--- a/game/forms.py
+++ b/game/forms.py
@@ -12,6 +12,8 @@ class QuestCreateForm(forms.Form):
 
 
 class AbilityCheckRequestForm(forms.ModelForm):
+    EMPTY_CHOICE = ("", "---------")
+
     class Meta:
         model = RollRequest
         fields = ["player", "ability_type", "difficulty_class"]
@@ -28,7 +30,10 @@ class AbilityCheckRequestForm(forms.ModelForm):
             widget=forms.Select(attrs={"class": "rpgui-dropdown"}),
         )
         self.fields["ability_type"].label = "Ability"
-        self.fields["ability_type"].choices = AbilityName.choices
+        self.fields["ability_type"].choices = [
+            self.EMPTY_CHOICE,
+            *AbilityName.choices,
+        ]
 
 
 class CombatCreateForm(forms.Form):


### PR DESCRIPTION
- Refactor EquipmentSelectForm to skip fields with no choices
- Refactor BackgroundForm to skip fields with no choices
- Refactor SkillsSelectForm to skip fields with no choices
- Add _get_choices() and _add_field_if_choices() helper methods

This improves UX by not showing empty dropdowns to users.