### PR TITLE
Handle Anthropic API errors gracefully in quest enrichment

### DIFF
--- a/ai/generators.py
+++ b/ai/generators.py
@@ -1,4 +1,8 @@
+import logging
+
 import anthropic
+
+logger = logging.getLogger(__name__)
 
 
 class TextGenerator:
@@ -18,16 +22,21 @@ class TextGenerator:
     def enrich_quest(self, prompt: str) -> str:
         """
         Enrich a quest environment based on the given prompt.
+        Returns the enriched text, or the original prompt if the API call fails.
         """
-        response = self.client.messages.create(
-            model=self.model,
-            max_tokens=2048,
-            system="You are a role play dungeon master.",
-            messages=[
-                {
-                    "role": "user",
-                    "content": f"{prompt}",
-                }
-            ],
-        )
-        return response.content[0].text
+        try:
+            response = self.client.messages.create(
+                model=self.model,
+                max_tokens=2048,
+                system="You are a role play dungeon master.",
+                messages=[
+                    {
+                        "role": "user",
+                        "content": f"{prompt}",
+                    }
+                ],
+            )
+            return response.content[0].text
+        except anthropic.APIStatusError as e:
+            logger.warning("Anthropic API error: %s. Using original prompt.", e)
+            return prompt

--- a/ai/test_generators.py
+++ b/ai/test_generators.py
@@ -1,3 +1,8 @@
+from unittest.mock import MagicMock, patch
+
+import anthropic
+import pytest
+
 from ai.generators import TextGenerator
 
 
@@ -5,3 +10,27 @@ def test_singleton_instance():
     instance1 = TextGenerator()
     instance2 = TextGenerator()
     assert instance1 is instance2
+
+
+@pytest.mark.django_db
+def test_enrich_quest_api_error_returns_original_prompt():
+    """Test that API errors are handled gracefully and return the original prompt."""
+    generator = TextGenerator()
+    original_prompt = "The heroes enter a dark cave"
+
+    mock_response = MagicMock()
+    mock_response.status_code = 402
+    mock_response.request = MagicMock()
+
+    with patch.object(
+        generator.client.messages,
+        "create",
+        side_effect=anthropic.APIStatusError(
+            message="Insufficient credits",
+            response=mock_response,
+            body=None,
+        ),
+    ):
+        result = generator.enrich_quest(original_prompt)
+
+    assert result == original_prompt


### PR DESCRIPTION
- Add try/except to catch APIStatusError in TextGenerator.enrich_quest()
- Return original prompt when API fails (e.g., insufficient credits)
- Log warning for debugging purposes
- Add test for error handling scenario