### PR TITLE
docs: update project to reference D&D SRD 5.2 specification

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This file provides guidance to AI coding assistants (GitHub Copilot, Claude Code
 
 **role-play** is a virtual role-playing game application built with Django. It allows people to play role-playing games remotely by following a story and performing actions like throwing dice or making choices.
 
+The game implements Dungeons & Dragons 5th Edition rules based on the **SRD 5.2** (Systems Reference Document version 5.2.1), which includes content from the 2024 D&D core rulebooks under the Creative Commons Attribution 4.0 International License.
+
 - **Language**: Python 3.14
 - **Framework**: Django 5.2
 - **Architecture**: Async-capable with Channels, WebSockets, and Celery for background tasks
@@ -239,7 +241,7 @@ The project is organized by domain (character, game, master, user) with each hav
 - **Under Development**: This is an active project; UI and features are evolving
 - **Real-time Features**: Uses WebSockets for real-time game interactions
 - **AI-Enhanced**: Quest descriptions and game content can be enriched using Claude AI
-- **License**: GNU Affero General Public License v3.0
+- **License**: GNU Affero General Public License v3.0 (application code); CC-BY-4.0 for D&D SRD 5.2 game content
 
 ## Related Documentation
 - `README.md` - Project overview and screenshots

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
 
 ## Unreleased
 
+### Changed
+* Updated project to reference D&D 5th Edition SRD 5.2 specification with CC-BY-4.0 attribution
+
 ## v0.13.0 - 2026-01-02
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -68,6 +68,22 @@ doppler run -- uv run poe test          # Run all tests
 doppler run -- uv run poe test-cov      # Run tests with coverage
 ```
 
+## 📜 D&D Rules Reference
+
+This project implements tabletop RPG gameplay based on the **Dungeons & Dragons 5th Edition System Reference Document (SRD) version 5.2** (also known as SRD 5.2.1), which is made available under the Creative Commons Attribution 4.0 International License (CC-BY-4.0) by Wizards of the Coast.
+
+The SRD 5.2 includes updated content from the 2024 D&D core rulebooks, featuring:
+- Updated class rules and progression
+- New species (Goliaths and Orcs added to SRD)
+- Enhanced feats and backgrounds system
+- Weapon Mastery mechanics
+- Updated monster statistics
+- Expanded gameplay toolbox and rules glossary
+
+**Reference:** [D&D Systems Reference Document 5.2](https://media.dndbeyond.com/compendium-images/srd/5.2/SRD_CC_v5.2.1.pdf)
+
 ## 📄 License
 
 This project is licensed under the [GNU Affero General Public License v3.0](LICENSE.md).
+
+Game rules and mechanics are based on the D&D 5th Edition SRD 5.2, which is licensed under CC-BY-4.0 by Wizards of the Coast.

--- a/game/templates/base.html
+++ b/game/templates/base.html
@@ -8,5 +8,22 @@
 
     <body>
         {% block content %}{% endblock%}
+
+        <footer style="text-align: center; padding: 20px; margin-top: 40px; border-top: 1px solid var(--color-border, #4a4a4a); font-size: 0.85rem; color: var(--color-text-muted, #999);">
+            <p style="margin: 5px 0;">
+                This virtual tabletop implements D&D 5th Edition rules based on the
+                <a href="https://media.dndbeyond.com/compendium-images/srd/5.2/SRD_CC_v5.2.1.pdf"
+                   style="color: var(--color-primary, #d4af37); text-decoration: underline;"
+                   target="_blank"
+                   rel="noopener noreferrer">Systems Reference Document 5.2</a>
+            </p>
+            <p style="margin: 5px 0;">
+                The SRD 5.2 is © Wizards of the Coast and licensed under
+                <a href="https://creativecommons.org/licenses/by/4.0/"
+                   style="color: var(--color-primary, #d4af37); text-decoration: underline;"
+                   target="_blank"
+                   rel="noopener noreferrer">CC-BY-4.0</a>
+            </p>
+        </footer>
     </body>
 </html>

--- a/game/templates/game/index.html
+++ b/game/templates/game/index.html
@@ -29,7 +29,7 @@
                     ⚔️ 🏰 🎲
                 </div>
                 <h2 class="panel-title" style="font-size: 1.5rem; margin-bottom: 15px;">Embark on Epic Adventures</h2>
-                <p class="mb-1">Welcome to <strong>Role Play</strong> – an open-source virtual tabletop implementation of Dungeons & Dragons! Experience the magic of the world's greatest roleplaying game online, powered by the D&D Basic Rules.</p>
+                <p class="mb-1">Welcome to <strong>Role Play</strong> – an open-source virtual tabletop implementation of Dungeons & Dragons! Experience the magic of the world's greatest roleplaying game online, powered by the D&D 5th Edition SRD 5.2.</p>
                 <p class="mb-2"><strong>What awaits you:</strong></p>
                 <ul style="text-align: left; margin: 0 auto 15px; max-width: 600px; line-height: 1.8;">
                     <li>🎭 <strong>Create unique characters</strong> with diverse races, classes, and abilities</li>


### PR DESCRIPTION
Update documentation and templates to reference the D&D 5th Edition System Reference Document version 5.2 (SRD 5.2.1), which includes content from the 2024 core rulebooks under CC-BY-4.0 license.

Changes:
- Add D&D Rules Reference section to README with SRD 5.2 details
- Update index.html to reference SRD 5.2 instead of Basic Rules
- Add SRD 5.2 context to AGENTS.md project overview
- Add footer to base.html with SRD 5.2 attribution and licensing

🤖 Generated with [Claude Code](https://claude.com/claude-code)