### PR TITLE
fix: use authenticated user instead of client-provided username

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
 
 ## Unreleased
 
+### Fixed
+* Use authenticated user instead of client-provided username in message storage and event enrichers (security fix)
+
 ### Changed
 * Updated project to reference D&D 5th Edition SRD 5.2 specification with CC-BY-4.0 attribution
 

--- a/game/commands.py
+++ b/game/commands.py
@@ -28,7 +28,7 @@ class ProcessMessageCommand(Command):
             game_id=game.id,
             date=content["date"],
             message=content["message"],
-            author_str=content["username"],
+            author_str=user.username,
         )
 
 

--- a/game/consumers.py
+++ b/game/consumers.py
@@ -68,18 +68,18 @@ class GameEventsConsumer(JsonWebsocketConsumer):
             match content["type"]:
                 case EventType.MESSAGE:
                     command = ProcessMessageCommand()
-                    event_enricher = MessageEnricher(self.game, content)
+                    event_enricher = MessageEnricher(self.game, content, self.user)
                 case EventType.ABILITY_CHECK_RESPONSE:
                     command = AbilityCheckResponseCommand()
-                    event_enricher = RollResponseEnricher(self.game, content)
+                    event_enricher = RollResponseEnricher(self.game, content, self.user)
                 case EventType.SAVING_THROW_RESPONSE:
                     command = SavingThrowResponseCommand()
-                    event_enricher = RollResponseEnricher(self.game, content)
+                    event_enricher = RollResponseEnricher(self.game, content, self.user)
                 case EventType.COMBAT_INITIALIZATION:
                     command = ProcessMessageCommand()
                 case EventType.COMBAT_INITIATIVE_RESPONSE:
                     command = CombatInitiativeResponseCommand()
-                    event_enricher = RollResponseEnricher(self.game, content)
+                    event_enricher = RollResponseEnricher(self.game, content, self.user)
                 case _:
                     pass
             try:

--- a/game/tests/test_event_enrichers.py
+++ b/game/tests/test_event_enrichers.py
@@ -20,10 +20,9 @@ class TestMessageEnricher:
         content = {
             "date": timezone.now(),
             "message": "Hello, players!",
-            "username": master.user.username,
         }
 
-        enricher = MessageEnricher(game, content)
+        enricher = MessageEnricher(game, content, master.user)
         enricher.enrich()
 
         assert content["message"] == "The Master said: Hello, players!"
@@ -34,27 +33,58 @@ class TestMessageEnricher:
         content = {
             "date": timezone.now(),
             "message": "Hello, master!",
-            "username": player.user.username,
         }
 
-        enricher = MessageEnricher(game, content)
+        enricher = MessageEnricher(game, content, player.user)
         enricher.enrich()
 
         assert content["message"] == f"{player} said: Hello, master!"
+
+    def test_enrich_uses_authenticated_user_not_content_username(self):
+        """Test that the authenticated user is used, not client-provided username."""
+        game = GameFactory()
+        master = game.master
+        content = {
+            "date": timezone.now(),
+            "message": "Hello!",
+            "username": "malicious_username",  # Client-provided, should be ignored
+        }
+
+        enricher = MessageEnricher(game, content, master.user)
+        enricher.enrich()
+
+        # Should use authenticated user (master), not content["username"]
+        assert content["message"] == "The Master said: Hello!"
 
 
 class TestRollResponseEnricher:
     def test_enrich_sets_ability_check_message(self):
         game = GameFactory()
         player = PlayerFactory(game=game)
+        user = player.character.user  # Use character's user (the authenticated user)
         content = {
             "date": timezone.now(),
-            "username": player.character.user.username,
         }
 
-        enricher = RollResponseEnricher(game, content)
+        enricher = RollResponseEnricher(game, content, user)
         enricher.enrich()
 
+        assert content["message"] == f"{player} performed an ability check!"
+
+    def test_enrich_uses_authenticated_user_not_content_username(self):
+        """Test that the authenticated user is used, not client-provided username."""
+        game = GameFactory()
+        player = PlayerFactory(game=game)
+        user = player.character.user
+        content = {
+            "date": timezone.now(),
+            "username": "malicious_username",  # Client-provided, should be ignored
+        }
+
+        enricher = RollResponseEnricher(game, content, user)
+        enricher.enrich()
+
+        # Should use authenticated user, not content["username"]
         assert content["message"] == f"{player} performed an ability check!"
 
 
@@ -62,12 +92,28 @@ class TestCombatInitiativeResponseEnricher:
     def test_enrich_sets_dexterity_check_message(self):
         game = GameFactory()
         player = PlayerFactory(game=game)
+        user = player.character.user  # Use character's user (the authenticated user)
         content = {
             "date": timezone.now(),
-            "username": player.character.user.username,
         }
 
-        enricher = CombatInitiativeResponseEnricher(game, content)
+        enricher = CombatInitiativeResponseEnricher(game, content, user)
         enricher.enrich()
 
+        assert content["message"] == f"{player.character} performed a dexterity check!"
+
+    def test_enrich_uses_authenticated_user_not_content_username(self):
+        """Test that the authenticated user is used, not client-provided username."""
+        game = GameFactory()
+        player = PlayerFactory(game=game)
+        user = player.character.user
+        content = {
+            "date": timezone.now(),
+            "username": "malicious_username",  # Client-provided, should be ignored
+        }
+
+        enricher = CombatInitiativeResponseEnricher(game, content, user)
+        enricher.enrich()
+
+        # Should use authenticated user, not content["username"]
         assert content["message"] == f"{player.character} performed a dexterity check!"


### PR DESCRIPTION
Previously, message storage and event enrichers used the username from the WebSocket message content (client-provided), which could cause lookup failures or security issues.

Now uses the authenticated user from the WebSocket scope, ensuring the server-verified identity is always used.

Changes:
- game/commands.py: Use user.username instead of content["username"]
- game/event_enrichers.py: Add user parameter to Enricher classes
- game/consumers.py: Pass self.user to enrichers
- Added tests to verify authenticated user is used

🤖 Generated with [Claude Code](https://claude.com/claude-code)