### PR TITLE
fix: resolve flaky test by removing session-scoped fixtures

### DIFF
--- a/game/tests/conftest.py
+++ b/game/tests/conftest.py
@@ -12,16 +12,20 @@ from .factories import (
 )
 
 
-@pytest.fixture(scope="session")
-def started_game(django_db_blocker):
-    with django_db_blocker.unblock():
-        game = GameFactory(master__user__username="master")
-        number_of_players = 3
-        for _ in range(number_of_players):
-            PlayerFactory(game=game)
-        flow = GameFlow(game)
-        flow.start()
-        return game
+@pytest.fixture
+def started_game(db):
+    """Create a started game with players.
+
+    Note: This fixture is function-scoped to avoid race conditions
+    with parallel test execution (pytest-xdist).
+    """
+    game = GameFactory()
+    number_of_players = 3
+    for _ in range(number_of_players):
+        PlayerFactory(game=game)
+    flow = GameFlow(game)
+    flow.start()
+    return game
 
 
 @pytest.fixture


### PR DESCRIPTION
Changed started_game fixtures from session/class scope to function scope to avoid race conditions with parallel test execution (pytest-xdist). Removed hardcoded "master" username and instead get the master user from the game fixture directly.