### PR TITLE
fix: remove nonexistent 'klasses' fixture reference

### DIFF
--- a/poe_tasks.toml
+++ b/poe_tasks.toml
@@ -29,7 +29,7 @@ ref = "db-migrate"
 
 [tasks.db-load-settings]
 help = "Load app settings (fixtures)"
-cmd = "manage.py loaddata advancement abilities languages klasses skills equipment conditions species_traits species feats classes class_features"
+cmd = "manage.py loaddata advancement abilities languages skills equipment conditions species_traits species feats classes class_features"
 
 [tasks.db-populate]
 help = "Populate the DB with realistic data"


### PR DESCRIPTION
The fixture file is 'classes.yaml', not 'klasses.yaml'.