### PR TITLE
fix: enable 24 skipped TestMonsterModel tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
 
 ## Unreleased
 
+### Fixed
+* Enabled 24 skipped `TestMonsterModel` tests - the `game.Combat` ForeignKey issue was resolved (nullable FK works correctly)
+
 ### Changed
 * Refactored WebSocket event system for simpler architecture:
   - Added `get_event_type()` method to all Event model subclasses, replacing 55-line isinstance chain

--- a/character/tests/models/test_monsters.py
+++ b/character/tests/models/test_monsters.py
@@ -382,9 +382,6 @@ class TestMonsterSettingsFixture:
 
 
 @pytest.mark.django_db
-@pytest.mark.skip(
-    reason="Skipped due to pre-existing game.Combat ForeignKey resolution issue"
-)
 class TestMonsterModel:
     """Tests for the Monster model (concrete instances)."""
 


### PR DESCRIPTION
The skip decorator was added due to a "pre-existing game.Combat ForeignKey resolution issue" that no longer exists. The ForeignKey is correctly defined with null=True, blank=True, and the tests don't require a Combat object.