### PR TITLE
feat: add spell card modal with parchment styling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
 ## Unreleased
 
 ### Added
+* Spell card modal for viewing full spell details:
+  - Parchment-styled modal with dark gradient background and subtle texture overlay
+  - Spell name header with ritual badge indicator when applicable
+  - Level and school subtitle (e.g., "3rd-level evocation" or "Divination cantrip")
+  - Metadata grid showing casting time, range, components, and duration
+  - Color-coded component badges (V=blue, S=green, M=yellow) with material details
+  - Animated concentration indicator with pulsing effect
+  - Decorative star divider between metadata and description
+  - Scrollable description area with custom parchment-style scrollbar
+  - "At Higher Levels" section highlighted with gold border
+  - Cast button for cantrips or level-selectable upcast buttons showing remaining slots
+  - Disabled upcast buttons when no slots available at that level
+  - Click spell names in spells panel to open the modal
+  - Close via button, clicking outside, or Escape key
+  - Responsive design with mobile breakpoints
+  - New view: SpellCardModalView
+  - New URL endpoint: character-spell-card
+  - Test coverage for spell card modal (12 tests)
 * Interactive spell management panel with HTMX for character spellcasting:
   - Visual spell slot tracker with clickable circles that fill/empty on use
   - Circles glow blue when filled (available), click to toggle used/available state

--- a/character/templates/character/partials/spell_card_modal.html
+++ b/character/templates/character/partials/spell_card_modal.html
@@ -1,0 +1,564 @@
+{% load static humanize %}
+
+<div id="spell-card-modal" class="rpg-modal {% if show_modal %}active{% endif %}">
+    <div class="modal-content spell-card-modal-content">
+        <span class="modal-close" onclick="closeSpellCardModal()">&times;</span>
+
+        <!-- Parchment Header -->
+        <div class="spell-card-header">
+            <div class="spell-card-title-row">
+                <h2 class="spell-card-title">{{ spell.name }}</h2>
+                {% if spell.ritual %}
+                    <span class="spell-ritual-badge" title="Can be cast as ritual">Ritual</span>
+                {% endif %}
+            </div>
+            <div class="spell-card-subtitle">
+                {% if spell.level == 0 %}
+                    {{ spell.get_school_display }} cantrip
+                {% else %}
+                    {{ spell.level|ordinal }}-level {{ spell.get_school_display|lower }}
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Spell Metadata Grid -->
+        <div class="spell-card-meta">
+            <div class="meta-row">
+                <span class="meta-label">Casting Time</span>
+                <span class="meta-value">
+                    {{ spell.get_casting_time_display }}
+                    {% if spell.casting_time_detail %}
+                        <span class="meta-detail">{{ spell.casting_time_detail }}</span>
+                    {% endif %}
+                </span>
+            </div>
+            <div class="meta-row">
+                <span class="meta-label">Range</span>
+                <span class="meta-value">
+                    {{ spell.get_range_display }}
+                    {% if spell.range_detail %}
+                        <span class="meta-detail">({{ spell.range_detail }})</span>
+                    {% endif %}
+                </span>
+            </div>
+            <div class="meta-row">
+                <span class="meta-label">Components</span>
+                <span class="meta-value">
+                    <span class="components-list">
+                        {% for comp in spell.components %}
+                            <span class="component-badge {{ comp|lower }}">{{ comp }}</span>
+                        {% endfor %}
+                    </span>
+                    {% if spell.material_components %}
+                        <span class="material-detail">({{ spell.material_components }}{% if spell.material_cost > 0 %}, {{ spell.material_cost }} gp{% if spell.material_consumed %}, consumed{% endif %}{% endif %})</span>
+                    {% endif %}
+                </span>
+            </div>
+            <div class="meta-row">
+                <span class="meta-label">Duration</span>
+                <span class="meta-value">
+                    {% if spell.concentration %}
+                        <span class="concentration-indicator" title="Requires concentration">
+                            <span class="conc-icon">&#9673;</span>
+                            Concentration,
+                        </span>
+                    {% endif %}
+                    {{ spell.get_duration_display }}
+                </span>
+            </div>
+        </div>
+
+        <!-- Decorative Divider -->
+        <div class="spell-card-divider"></div>
+
+        <!-- Spell Description -->
+        <div class="spell-card-description">
+            <div class="description-scroll">
+                <p>{{ spell.description|linebreaks }}</p>
+            </div>
+        </div>
+
+        <!-- At Higher Levels -->
+        {% if spell.higher_levels %}
+            <div class="spell-card-higher-levels">
+                <div class="higher-levels-header">At Higher Levels</div>
+                <p>{{ spell.higher_levels }}</p>
+            </div>
+        {% endif %}
+
+        <!-- Cast Actions -->
+        {% if character %}
+            <div class="spell-card-actions">
+                {% if is_cantrip %}
+                    <button type="button"
+                            class="rpg-btn btn-primary cast-btn"
+                            hx-post="{% url 'character-cast-spell' character.pk %}"
+                            hx-vals='{"spell_name": "{{ spell.name }}", "cast_level": "0"}'
+                            hx-target="#spells-panel-component"
+                            hx-swap="outerHTML"
+                            onclick="closeSpellCardModal()">
+                        <span class="cast-icon">&#9889;</span>
+                        Cast Cantrip
+                    </button>
+                {% else %}
+                    <div class="upcast-section">
+                        <label class="upcast-label">Cast at Level:</label>
+                        <div class="upcast-options">
+                            {% for slot in available_slots %}
+                                <button type="button"
+                                        class="upcast-btn {% if not slot.available %}disabled{% endif %} {% if slot.level == spell.level %}base-level{% endif %}"
+                                        {% if slot.available %}
+                                            hx-post="{% url 'character-cast-spell' character.pk %}"
+                                            hx-vals='{"spell_name": "{{ spell.name }}", "cast_level": "{{ slot.level }}"}'
+                                            hx-target="#spells-panel-component"
+                                            hx-swap="outerHTML"
+                                            onclick="closeSpellCardModal()"
+                                        {% endif %}
+                                        title="{% if slot.available %}Cast at level {{ slot.level }} ({{ slot.remaining }}/{{ slot.total }} slots){% else %}No slots available{% endif %}">
+                                    <span class="upcast-level">{{ slot.level }}</span>
+                                    <span class="upcast-slots">{{ slot.remaining }}/{{ slot.total }}</span>
+                                </button>
+                            {% empty %}
+                                <span class="no-slots-message">No spell slots available</span>
+                            {% endfor %}
+                        </div>
+                    </div>
+                {% endif %}
+                <button type="button" class="rpg-btn" onclick="closeSpellCardModal()">Close</button>
+            </div>
+        {% else %}
+            <div class="spell-card-actions">
+                <button type="button" class="rpg-btn" onclick="closeSpellCardModal()">Close</button>
+            </div>
+        {% endif %}
+    </div>
+</div>
+
+<style>
+/* Spell Card Modal - Parchment/Scroll Style */
+    .spell-card-modal-content {
+        min-width: 400px;
+        max-width: 550px;
+        background: linear-gradient(
+            180deg,
+            rgba(45, 40, 35, 0.98) 0%,
+            rgba(35, 30, 25, 0.98) 50%,
+            rgba(40, 35, 30, 0.98) 100%
+        );
+        border: 2px solid rgba(212, 175, 55, 0.4);
+        box-shadow:
+        0 0 30px rgba(0, 0, 0, 0.8),
+        inset 0 0 60px rgba(139, 115, 85, 0.1),
+        0 0 15px rgba(212, 175, 55, 0.2);
+        position: relative;
+    }
+
+/* Parchment texture overlay */
+    .spell-card-modal-content::before {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background:
+        url("data:image/svg+xml,%3Csvg viewBox='0 0 200 200' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
+        opacity: 0.03;
+        pointer-events: none;
+        border-radius: inherit;
+    }
+
+/* Header Section */
+    .spell-card-header {
+        text-align: center;
+        margin-bottom: 20px;
+        padding-bottom: 15px;
+        border-bottom: 1px solid rgba(212, 175, 55, 0.3);
+        position: relative;
+    }
+
+    .spell-card-header::after {
+        content: '';
+        position: absolute;
+        bottom: -1px;
+        left: 50%;
+        transform: translateX(-50%);
+        width: 60%;
+        height: 1px;
+        background: linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.6), transparent);
+    }
+
+    .spell-card-title-row {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 10px;
+        flex-wrap: wrap;
+    }
+
+    .spell-card-title {
+        font-family: 'Georgia', 'Times New Roman', serif;
+        font-size: 1.8rem;
+        color: var(--color-primary);
+        margin: 0;
+        text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+        letter-spacing: 0.5px;
+    }
+
+    .spell-ritual-badge {
+        background: rgba(155, 89, 182, 0.3);
+        color: #9b59b6;
+        padding: 3px 8px;
+        border-radius: 4px;
+        font-size: 0.75rem;
+        font-weight: 600;
+        text-transform: uppercase;
+        border: 1px solid rgba(155, 89, 182, 0.5);
+    }
+
+    .spell-card-subtitle {
+        color: var(--color-text-muted);
+        font-size: 1rem;
+        font-style: italic;
+        margin-top: 5px;
+    }
+
+/* Metadata Grid */
+    .spell-card-meta {
+        background: rgba(0, 0, 0, 0.3);
+        border-radius: 8px;
+        padding: 15px;
+        margin-bottom: 20px;
+        border: 1px solid rgba(139, 115, 85, 0.2);
+    }
+
+    .meta-row {
+        display: flex;
+        padding: 8px 0;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+    }
+
+    .meta-row:last-child {
+        border-bottom: none;
+        padding-bottom: 0;
+    }
+
+    .meta-row:first-child {
+        padding-top: 0;
+    }
+
+    .meta-label {
+        flex: 0 0 110px;
+        font-weight: 600;
+        color: var(--color-primary);
+        font-size: 0.9rem;
+    }
+
+    .meta-value {
+        flex: 1;
+        color: var(--color-text);
+        font-size: 0.9rem;
+        line-height: 1.4;
+    }
+
+    .meta-detail {
+        color: var(--color-text-muted);
+        font-size: 0.85rem;
+    }
+
+    .material-detail {
+        display: block;
+        color: var(--color-text-muted);
+        font-size: 0.85rem;
+        margin-top: 4px;
+        font-style: italic;
+    }
+
+/* Components Badges */
+    .components-list {
+        display: inline-flex;
+        gap: 5px;
+    }
+
+    .component-badge {
+        display: inline-block;
+        padding: 2px 8px;
+        border-radius: 4px;
+        font-size: 0.8rem;
+        font-weight: 600;
+        text-transform: uppercase;
+    }
+
+    .component-badge.v {
+        background: rgba(52, 152, 219, 0.2);
+        color: #3498db;
+        border: 1px solid rgba(52, 152, 219, 0.4);
+    }
+
+    .component-badge.s {
+        background: rgba(46, 204, 113, 0.2);
+        color: #2ecc71;
+        border: 1px solid rgba(46, 204, 113, 0.4);
+    }
+
+    .component-badge.m {
+        background: rgba(241, 196, 15, 0.2);
+        color: #f1c40f;
+        border: 1px solid rgba(241, 196, 15, 0.4);
+    }
+
+/* Concentration Indicator */
+    .concentration-indicator {
+        color: var(--color-exp);
+        font-weight: 600;
+    }
+
+    .conc-icon {
+        display: inline-block;
+        animation: concentrationPulse 2s ease-in-out infinite;
+    }
+
+    @keyframes concentrationPulse {
+        0%, 100% { opacity: 1; }
+        50% { opacity: 0.5; }
+    }
+
+/* Decorative Divider */
+    .spell-card-divider {
+        height: 2px;
+        background: linear-gradient(90deg, transparent, rgba(212, 175, 55, 0.5), transparent);
+        margin: 20px 0;
+        position: relative;
+    }
+
+    .spell-card-divider::before {
+        content: '\2726';
+        position: absolute;
+        left: 50%;
+        top: 50%;
+        transform: translate(-50%, -50%);
+        background: rgba(35, 30, 25, 1);
+        padding: 0 10px;
+        color: var(--color-primary);
+        font-size: 0.9rem;
+    }
+
+/* Description Section */
+    .spell-card-description {
+        margin-bottom: 20px;
+    }
+
+    .description-scroll {
+        max-height: 200px;
+        overflow-y: auto;
+        padding-right: 10px;
+        line-height: 1.6;
+        color: var(--color-text);
+        font-size: 0.95rem;
+    }
+
+    .description-scroll p {
+        margin: 0 0 10px 0;
+    }
+
+    .description-scroll p:last-child {
+        margin-bottom: 0;
+    }
+
+/* Custom scrollbar for parchment feel */
+    .description-scroll::-webkit-scrollbar {
+        width: 8px;
+    }
+
+    .description-scroll::-webkit-scrollbar-track {
+        background: rgba(0, 0, 0, 0.2);
+        border-radius: 4px;
+    }
+
+    .description-scroll::-webkit-scrollbar-thumb {
+        background: linear-gradient(180deg, #8b7355, #6b5344);
+        border-radius: 4px;
+        border: 1px solid rgba(139, 115, 85, 0.3);
+    }
+
+    .description-scroll::-webkit-scrollbar-thumb:hover {
+        background: linear-gradient(180deg, #9b8365, #7b6354);
+    }
+
+/* Higher Levels Section */
+    .spell-card-higher-levels {
+        background: rgba(212, 175, 55, 0.1);
+        border: 1px solid rgba(212, 175, 55, 0.3);
+        border-radius: 8px;
+        padding: 12px 15px;
+        margin-bottom: 20px;
+    }
+
+    .higher-levels-header {
+        font-weight: 700;
+        color: var(--color-primary);
+        margin-bottom: 8px;
+        font-size: 0.9rem;
+        text-transform: uppercase;
+        letter-spacing: 0.5px;
+    }
+
+    .spell-card-higher-levels p {
+        margin: 0;
+        color: var(--color-text);
+        font-size: 0.9rem;
+        line-height: 1.5;
+    }
+
+/* Actions Section */
+    .spell-card-actions {
+        display: flex;
+        flex-direction: column;
+        gap: 15px;
+        padding-top: 20px;
+        border-top: 1px solid rgba(255, 255, 255, 0.1);
+    }
+
+    .cast-btn {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        gap: 8px;
+        font-size: 1rem;
+        padding: 12px 20px;
+    }
+
+    .cast-icon {
+        font-size: 1.2rem;
+    }
+
+/* Upcast Section */
+    .upcast-section {
+        background: rgba(0, 0, 0, 0.2);
+        border-radius: 8px;
+        padding: 15px;
+    }
+
+    .upcast-label {
+        display: block;
+        color: var(--color-text);
+        font-weight: 600;
+        margin-bottom: 10px;
+        font-size: 0.9rem;
+    }
+
+    .upcast-options {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 8px;
+    }
+
+    .upcast-btn {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        min-width: 55px;
+        padding: 10px 12px;
+        background: rgba(0, 0, 0, 0.4);
+        border: 2px solid var(--color-border);
+        border-radius: 8px;
+        color: var(--color-text);
+        cursor: pointer;
+        transition: all 0.2s ease;
+        font-family: inherit;
+    }
+
+    .upcast-btn:hover:not(.disabled) {
+        border-color: var(--color-primary);
+        background: rgba(212, 175, 55, 0.1);
+        transform: translateY(-2px);
+    }
+
+    .upcast-btn.base-level {
+        border-color: var(--color-primary);
+        background: rgba(212, 175, 55, 0.15);
+    }
+
+    .upcast-btn.disabled {
+        opacity: 0.4;
+        cursor: not-allowed;
+    }
+
+    .upcast-level {
+        font-size: 1.2rem;
+        font-weight: 700;
+        color: var(--color-primary);
+    }
+
+    .upcast-slots {
+        font-size: 0.75rem;
+        color: var(--color-text-muted);
+        margin-top: 2px;
+    }
+
+    .no-slots-message {
+        color: var(--color-health);
+        font-style: italic;
+        padding: 10px;
+    }
+
+    .spell-card-actions > .rpg-btn:last-child {
+        align-self: flex-end;
+    }
+
+/* Responsive */
+    @media (max-width: 500px) {
+        .spell-card-modal-content {
+            min-width: auto;
+            max-width: 100%;
+            margin: 10px;
+        }
+
+        .spell-card-title {
+            font-size: 1.5rem;
+        }
+
+        .meta-label {
+            flex: 0 0 90px;
+            font-size: 0.85rem;
+        }
+
+        .meta-value {
+            font-size: 0.85rem;
+        }
+
+        .description-scroll {
+            max-height: 150px;
+        }
+
+        .upcast-btn {
+            min-width: 48px;
+            padding: 8px 10px;
+        }
+    }
+</style>
+
+<script>
+    function closeSpellCardModal() {
+        const modal = document.getElementById('spell-card-modal');
+        if (modal) {
+            modal.classList.remove('active');
+        }
+    }
+
+// Close modal on escape key
+    document.addEventListener('keydown', function(event) {
+        if (event.key === 'Escape') {
+            closeSpellCardModal();
+        }
+    });
+
+// Close modal when clicking outside content
+    document.addEventListener('click', function(event) {
+        const modal = document.getElementById('spell-card-modal');
+        if (event.target === modal) {
+            closeSpellCardModal();
+        }
+    });
+</script>

--- a/character/templates/character/partials/spells_panel.html
+++ b/character/templates/character/partials/spells_panel.html
@@ -1,4 +1,7 @@
 <div id="spells-panel-component" class="spells-panel-component">
+    <!-- Spell Card Modal Container -->
+    <div id="spell-card-modal" class="rpg-modal"></div>
+
     <!-- Cast Result Message -->
     {% if cast_result %}
         <div class="cast-result-message">
@@ -234,7 +237,14 @@
                                         {% endif %}
                                     </div>
                                     <div class="spell-name-box">
-                                        <span class="spell-name">{{ spell.settings.name }}</span>
+                                        <button type="button"
+                                                class="spell-name-btn"
+                                                hx-get="{% url 'character-spell-card' character.pk spell.settings.name %}"
+                                                hx-target="#spell-card-modal"
+                                                hx-swap="outerHTML"
+                                                title="View spell details">
+                                            <span class="spell-name">{{ spell.settings.name }}</span>
+                                        </button>
                                         {% if spell.always_prepared %}
                                             <span class="always-prepared-badge" title="Always Prepared">&#9733;</span>
                                         {% endif %}
@@ -298,7 +308,14 @@
                                         {% endif %}
                                     </div>
                                     <div class="spell-name-box">
-                                        <span class="spell-name">{{ spell.settings.name }}</span>
+                                        <button type="button"
+                                                class="spell-name-btn"
+                                                hx-get="{% url 'character-spell-card' character.pk spell.settings.name %}"
+                                                hx-target="#spell-card-modal"
+                                                hx-swap="outerHTML"
+                                                title="View spell details">
+                                            <span class="spell-name">{{ spell.settings.name }}</span>
+                                        </button>
                                     </div>
                                     <div class="spell-school-box">
                                         <span class="spell-school {{ spell.settings.school }}">
@@ -847,6 +864,22 @@
     .always-prepared-badge {
         color: var(--color-primary);
         font-size: 0.8rem;
+    }
+
+    .spell-name-btn {
+        background: none;
+        border: none;
+        padding: 0;
+        cursor: pointer;
+        text-align: left;
+        font-family: inherit;
+        max-width: 100%;
+        transition: color 0.2s ease;
+    }
+
+    .spell-name-btn:hover .spell-name {
+        color: var(--color-primary);
+        text-decoration: underline;
     }
 
     .spell-school-box {

--- a/character/urls.py
+++ b/character/urls.py
@@ -16,6 +16,7 @@ from .views.spells import (
     CastSpellView,
     RestoreAllSlotsView,
     RestoreSpellSlotView,
+    SpellCardModalView,
     SpellsPanelView,
     UseSpellSlotView,
 )
@@ -108,5 +109,10 @@ urlpatterns = [
         "<int:pk>/spells/concentration/break/",
         BreakConcentrationView.as_view(),
         name="character-break-concentration",
+    ),
+    path(
+        "<int:pk>/spells/<str:spell_name>/",
+        SpellCardModalView.as_view(),
+        name="character-spell-card",
     ),
 ]


### PR DESCRIPTION
Add an interactive modal that displays full spell details when clicking on spell names in the spells panel. Features include:

- Parchment-styled design with dark gradient and texture overlay
- Spell metadata grid (casting time, range, components, duration)
- Color-coded component badges (V=blue, S=green, M=yellow)
- Animated concentration indicator
- Scrollable description with custom scrollbar
- "At Higher Levels" section with gold highlight
- Upcast buttons showing available spell slots per level
- Cast button for cantrips
- Responsive design with mobile breakpoints
- 11 new tests for comprehensive coverage