### PR TITLE
fix: add CI gate job to ensure badge fails when any job fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,3 +77,19 @@ jobs:
         uses: codecov/codecov-action@v5
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  ci:
+    name: CI
+    if: always()
+    needs: [lint, test]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check results
+        env:
+          LINT_RESULT: ${{ needs.lint.result }}
+          TEST_RESULT: ${{ needs.test.result }}
+        run: |
+          if [[ "$LINT_RESULT" != "success" || "$TEST_RESULT" != "success" ]]; then
+            echo "One or more jobs failed"
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
   - Documented all event types, combat system, and character creation flow
 
 ### Fixed
+* Added CI gate job to ensure badge and workflow status fail when any job fails
 * Fixed flaky tests in CI caused by parallel test execution with shared PostgreSQL database
   - CI now runs tests serially (`-n 0`) to avoid race conditions and duplicate key violations
   - Made `TestSkillModel` tests more robust by handling missing fixtures gracefully


### PR DESCRIPTION
## Summary
- Adds a `ci` gate job that depends on both `lint` and `test` jobs
- Uses `if: always()` to run even when dependencies fail or are cancelled
- Explicitly checks each job's result and fails if any didn't succeed
- Ensures the CI badge and workflow status correctly reflect all job outcomes

## Test plan
- [ ] Verify CI workflow runs all three jobs (lint, test, ci)
- [ ] Verify the `ci` gate job fails when either `lint` or `test` fails
- [ ] Verify the CI badge reflects the correct status

🤖 Generated with [Claude Code](https://claude.com/claude-code)