### PR TITLE
fix: update Docker base image from bookworm-slim to trixie-slim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
   - Documented all event types, combat system, and character creation flow
 
 ### Fixed
+* Fixed deployment failure by updating Docker base image from removed `bookworm-slim` to `trixie-slim` (uv 0.9+)
 * Fixed flaky tests in CI caused by parallel test execution with shared PostgreSQL database
   - CI now runs tests serially (`-n 0`) to avoid race conditions and duplicate key violations
   - Made `TestSkillModel` tests more robust by handling missing fixtures gracefully

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.14-bookworm-slim
+FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1


### PR DESCRIPTION
## Summary
- uv 0.9 (2026-01-29) removed Debian Bookworm images in favor of Trixie (Debian 13)
- The `python3.14-bookworm-slim` tag no longer exists on GHCR, causing systematic deployment failures
- Updates base image to `python3.14-trixie-slim`

## Test plan
- [ ] Verify deployment succeeds with the new base image
- [ ] Verify health check passes after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)