### PR TITLE
docs: add Fly.io deployment status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 [![Renovate enabled](https://img.shields.io/badge/renovate-enabled-brightgreen.svg)](https://renovatebot.com)
 [![CI status](https://github.com/egraba/role-play/actions/workflows/ci.yml/badge.svg)](https://github.com/egraba/role-play/actions)
 [![codecov](https://codecov.io/gh/egraba/role-play/graph/badge.svg?token=Z3E788461G)](https://codecov.io/gh/egraba/role-play)
+[![Fly Deploy](https://github.com/egraba/role-play/actions/workflows/fly-deploy.yml/badge.svg)](https://github.com/egraba/role-play/actions/workflows/fly-deploy.yml)
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Fly.io deployment workflow status badge to README, linking to the `fly-deploy.yml` GitHub Actions workflow

## Test plan
- [ ] Verify badge renders correctly on GitHub
- [ ] Verify badge links to the Fly Deploy workflow page

🤖 Generated with [Claude Code](https://claude.com/claude-code)