### PR TITLE
fix: switch Docker base image from GHCR to Docker Hub

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
   - Documented all event types, combat system, and character creation flow
 
 ### Fixed
+* Fixed deployment failure by switching Docker base image from GHCR (`ghcr.io/astral-sh/uv`) to Docker Hub (`python:3.14-slim-trixie`) with standalone uv installer to avoid GHCR availability issues
 * Fixed deployment failure by updating Docker base image from removed `bookworm-slim` to `trixie-slim` (uv 0.9+)
 * Fixed flaky tests in CI caused by parallel test execution with shared PostgreSQL database
   - CI now runs tests serially (`-n 0`) to avoid race conditions and duplicate key violations

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/astral-sh/uv:python3.14-trixie-slim
+FROM python:3.14-slim-trixie
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
@@ -13,6 +13,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     gnupg \
     ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+
+# Install uv
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
+    && ln -s /root/.local/bin/uv /usr/local/bin/uv \
+    && ln -s /root/.local/bin/uvx /usr/local/bin/uvx
 
 # Install Doppler CLI using the recommended method
 RUN curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' \


### PR DESCRIPTION
## Summary
- Replaced `ghcr.io/astral-sh/uv:python3.14-trixie-slim` base image with `python:3.14-slim-trixie` from Docker Hub
- Installs uv via the official standalone installer (`astral.sh/uv/install.sh`) instead of relying on the GHCR-hosted uv image
- Eliminates GHCR as a dependency entirely, avoiding intermittent availability issues that were causing deployment failures

## Test plan
- [ ] Verify Fly.io deployment succeeds with the new base image
- [ ] Confirm uv is correctly installed and available in the container
- [ ] Confirm application starts normally (`doppler run -- uv run poe prod-run`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)