### PR TITLE
fix: add uv install path to Docker PATH for reliable builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,8 +27,10 @@ Versions follow [Semantic Versioning](https://semver.org/) (`<major>.<minor>.<pa
   - Documented all event types, combat system, and character creation flow
 
 ### Fixed
-* Fixed deployment failure by switching Docker base image from GHCR (`ghcr.io/astral-sh/uv`) to Docker Hub (`python:3.14-slim-trixie`) with standalone uv installer to avoid GHCR availability issues
-* Fixed deployment failure by updating Docker base image from removed `bookworm-slim` to `trixie-slim` (uv 0.9+)
+* Fixed recurring Docker deployment failures:
+  - Switched base image from GHCR (`ghcr.io/astral-sh/uv`) to Docker Hub (`python:3.14-slim-trixie`)
+  - Updated base image from removed `bookworm-slim` to `trixie-slim` (uv 0.9+)
+  - Fixed `uv: not found` by adding `/root/.local/bin` to PATH instead of relying on fragile symlinks
 * Fixed flaky tests in CI caused by parallel test execution with shared PostgreSQL database
   - CI now runs tests serially (`-n 0`) to avoid race conditions and duplicate key violations
   - Made `TestSkillModel` tests more robust by handling missing fixtures gracefully

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,7 @@ ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
 ENV UV_COMPILE_BYTECODE=1
 ENV UV_LINK_MODE=copy
+ENV PATH="/root/.local/bin:$PATH"
 
 # Install system dependencies
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -15,9 +16,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv
-RUN curl -LsSf https://astral.sh/uv/install.sh | sh \
-    && ln -s /root/.local/bin/uv /usr/local/bin/uv \
-    && ln -s /root/.local/bin/uvx /usr/local/bin/uvx
+RUN curl -LsSf https://astral.sh/uv/install.sh | sh
 
 # Install Doppler CLI using the recommended method
 RUN curl -sLf --retry 3 --tlsv1.2 --proto "=https" 'https://packages.doppler.com/public/cli/gpg.DE2A7741A397C129.key' \


### PR DESCRIPTION
## Summary
- Fixes `uv: not found` Docker build failure by adding `/root/.local/bin` to `PATH` instead of relying on fragile symlinks from the uv install script
- Consolidated deployment-related CHANGELOG entries into a single grouped item

## Test plan
- [ ] Verify Docker image builds successfully in CI
- [ ] Verify deployment health check passes on Fly.io

🤖 Generated with [Claude Code](https://claude.com/claude-code)