### PR TITLE
fix: resolve Renovate config causing undefined repository errors

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -11,8 +11,8 @@
   "packageRules": [
     {
       "description": "Group Django and Django-related packages",
-      "matchPackagePatterns": [
-        "^[Dd]jango"
+      "matchPackageNames": [
+        "/^[Dd]jango/"
       ],
       "groupName": "Django packages"
     },
@@ -60,8 +60,6 @@
   ],
   "enabledManagers": [
     "pep621",
-    "uv",
-    "pip_requirements",
     "dockerfile",
     "docker-compose",
     "github-actions",


### PR DESCRIPTION
## Summary
- Replace deprecated `matchPackagePatterns` with `matchPackageNames` regex syntax
- Remove invalid `pip_requirements` manager (correct name is `pip-requirements`, and `requirements.txt` is auto-generated by uv anyway)
- Remove `uv` manager to avoid conflicts with `pep621` which already handles `pyproject.toml` and `uv.lock`

## Context
Renovate shows "Repository problems — Reason: undefined, Message: undefined" in the Mend dashboard and hasn't created any PRs since January 2025. These config issues are the likely cause of the silent crash.

## Test plan
- [ ] Merge to main and trigger a manual Renovate scan from the Mend dashboard
- [ ] Verify the Dependency Dashboard issue gets created
- [ ] Verify Renovate opens dependency update PRs on next scheduled run

🤖 Generated with [Claude Code](https://claude.com/claude-code)